### PR TITLE
refactor: Ensure hero section is full viewport width

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -30,7 +30,7 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased flex flex-col min-h-screen`}
       >
         <Navbar />
-        <main className="flex-grow container mx-auto p-4">
+        <main className="flex-grow"> {/* Odebrány třídy container, mx-auto, p-4 */}
           {children}
         </main>
         <Footer />

--- a/components/layout/PageContainer.tsx
+++ b/components/layout/PageContainer.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+interface PageContainerProps {
+  children: React.ReactNode;
+}
+
+const PageContainer: React.FC<PageContainerProps> = ({ children }) => {
+  return (
+    <div className="container mx-auto px-4 py-6 sm:py-8">
+      {children}
+    </div>
+  );
+};
+
+export default PageContainer;


### PR DESCRIPTION
- Modified `app/layout.tsx` by removing `container mx-auto p-4` from the `main` element. This allows child sections like the hero section on `app/page.tsx` to span the full viewport width and height.
- The hero section in `app/page.tsx` should now correctly cover the entire screen without external margins or padding.
- Created `components/layout/PageContainer.tsx` component to provide a standard containerized layout (limited width, padding) for future pages that require it.