### PR TITLE
feat: Add 'Portfolio' section with multi-item carousel

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -24,3 +24,51 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+/* Custom Swiper Navigation Styles for Portfolio Carousel */
+.portfolio-swiper {
+  /* Umožní šipkám jít mírně mimo, pokud je potřeba */
+  /* overflow: visible;  Zvážit, zda je nutné, Swiper to může řešit sám */
+  position: relative; /* Důležité pro absolutní pozicování šipek vůči tomuto kontejneru */
+}
+
+.portfolio-swiper .swiper-button-prev,
+.portfolio-swiper .swiper-button-next {
+  color: black; /* Nastaví barvu ikony šipky na černou */
+  top: 50%; /* Vertikální centrování */
+  transform: translateY(-50%);
+  width: 30px; /* Můžeme upravit velikost kontejneru šipky */
+  height: 30px;
+  /* Další styly pro pozadí, border-radius atd., pokud bychom chtěli tlačítkový vzhled */
+  /* background-color: rgba(255, 255, 255, 0.7); */
+  /* border-radius: 50%; */
+}
+
+.portfolio-swiper .swiper-button-prev::after,
+.portfolio-swiper .swiper-button-next::after {
+  font-size: 20px; /* Upraví velikost samotné ikony šipky */
+  font-weight: bold;
+}
+
+/* Posunutí šipek mírně vně obsahu slidů */
+/* Tyto hodnoty bude možná potřeba doladit podle finálního vzhledu a mezer */
+.portfolio-swiper .swiper-button-prev {
+  left: -10px;
+}
+
+.portfolio-swiper .swiper-button-next {
+  right: -10px;
+}
+
+/* Skrytí šipek na velmi malých obrazovkách, kde je jen jeden slide a loop nemusí být aktivní */
+@media (max-width: 549px) {
+  .portfolio-swiper .swiper-button-prev,
+  .portfolio-swiper .swiper-button-next {
+    /* Pokud je loop neaktivní a je jen jeden slide, Swiper šipky automaticky skryje nebo disabluje.
+       Toto je spíše pojistka, nebo pokud bychom je chtěli explicitně skrýt.
+       Prozatím necháme Swiper, ať si to řeší sám. Pokud budou vidět a nebudou funkční,
+       můžeme je zde skrýt.
+    */
+    /* display: none; */
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,5 @@
-import ReviewsCarousel from '@/components/reviews/ReviewsCarousel'; // Přidán import
+import ReviewsCarousel from '@/components/reviews/ReviewsCarousel';
+import PortfolioCarousel from '@/components/portfolio/PortfolioCarousel'; // Přidán import pro PortfolioCarousel
 
 export default function Home() {
   const heroBackgroundImage = '/images/homepageImages/uvodni_foto_vetsi.jpeg'; // Ujistěte se, že tento obrázek existuje v public/images/homepageImages/
@@ -108,6 +109,16 @@ export default function Home() {
             Vaše reakce
           </h2>
           <ReviewsCarousel />
+        </div>
+      </section>
+
+      {/* Sekce Portfolio */}
+      <section id="portfolio" className="bg-[#fdd154] py-12 sm:py-16 md:py-20">
+        <div className="container mx-auto px-4">
+          <h2 className="text-3xl sm:text-4xl font-bold text-center text-gray-800 mb-8 sm:mb-12">
+            Portfolio
+          </h2>
+          <PortfolioCarousel />
         </div>
       </section>
     </main>

--- a/components/portfolio/PortfolioCarousel.tsx
+++ b/components/portfolio/PortfolioCarousel.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import React from 'react';
+// Import Swiper React components
+import { Swiper, SwiperSlide } from 'swiper/react';
+// Import Swiper styles
+import 'swiper/css';
+import 'swiper/css/navigation';
+// import Swiper core and required modules
+import { Navigation } from 'swiper/modules';
+
+// Data pro karusel - UŽIVATEL MUSÍ NAHRÁT OBRÁZKY DO public/uploads/categories/
+const portfolioItems = [
+  { id: 1, src: '/uploads/categories/pary.jpg', category: 'Páry' },
+  { id: 2, src: '/uploads/categories/mazlicci.jpg', category: 'Mazlíčci' },
+  { id: 3, src: '/uploads/categories/svatby.jpg', category: 'Svatby' },
+  { id: 4, src: '/uploads/categories/glamour.jpg', category: 'Glamour/Akty' },
+  { id: 5, src: '/uploads/categories/tehotenske.jpg', category: 'Těhotenské' },
+  // Přidávám šestou položku pro lepší funkčnost loopu, pokud by bylo málo slidů
+  { id: 6, src: '/uploads/categories/rodinne.jpg', category: 'Rodinné' },
+];
+
+const PortfolioCarousel: React.FC = () => {
+  if (portfolioItems.length === 0) {
+    return <p className="text-center text-gray-500">Žádné portfolio k zobrazení.</p>;
+  }
+
+  return (
+    <div className="w-full relative">
+      <Swiper
+        modules={[Navigation]}
+        modules={[Navigation]}
+        navigation={true}
+        loop={portfolioItems.length >= 8} // Potřebujeme alespoň 2x max slidesPerView pro plynulý loop
+        slidesPerView={1} // Výchozí pro šířky < 550px
+        spaceBetween={10}  // Menší mezera pro jeden slide
+        breakpoints={{
+          // od 550px do 799px
+          550: {
+            slidesPerView: 2,
+            spaceBetween: 15,
+          },
+          // od 800px do 1029px
+          800: {
+            slidesPerView: 3,
+            spaceBetween: 20,
+          },
+          // od 1030px a více
+          1030: {
+            slidesPerView: 4,
+            spaceBetween: 20,
+          },
+        }}
+        className="portfolio-swiper"
+      >
+        {portfolioItems.map((item) => (
+          <SwiperSlide key={item.id}>
+            <div className="relative aspect-square bg-gray-200">
+              <img
+                src={item.src}
+                alt={`Portfolio fotografie - ${item.category}`}
+                className="w-full h-full object-cover" // object-cover vyplní čtverec
+              />
+              <div
+                className="absolute bottom-[15px] left-[15px] right-[15px] bg-white text-black text-center py-2 px-3 rounded-[10px] shadow-md"
+              >
+                {item.category}
+              </div>
+            </div>
+          </SwiperSlide>
+        ))}
+      </Swiper>
+      {/* Zde můžeme přidat kontejnery pro vlastní šipky, pokud by výchozí nevyhovovaly */}
+      {/* Např. <div className="swiper-button-prev"></div> <div className="swiper-button-next"></div> */}
+    </div>
+  );
+};
+
+export default PortfolioCarousel;

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "next": "15.3.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-responsive-carousel": "^3.2.23"
+    "react-responsive-carousel": "^3.2.23",
+    "swiper": "^11.2.10"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       react-responsive-carousel:
         specifier: ^3.2.23
         version: 3.2.23
+      swiper:
+        specifier: ^11.2.10
+        version: 11.2.10
     devDependencies:
       '@eslint/eslintrc':
         specifier: ^3
@@ -1766,6 +1769,10 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  swiper@11.2.10:
+    resolution: {integrity: sha512-RMeVUUjTQH+6N3ckimK93oxz6Sn5la4aDlgPzB+rBrG/smPdCTicXyhxa+woIpopz+jewEloiEE3lKo1h9w2YQ==}
+    engines: {node: '>= 4.7.0'}
 
   tailwindcss@4.1.11:
     resolution: {integrity: sha512-2E9TBm6MDD/xKYe+dvJZAmg3yxIEDNRc0jwlNyDg/4Fil2QcSLjFKGVff0lAf1jjeaArlG/M75Ey/EYr/OJtBA==}
@@ -3748,6 +3755,8 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  swiper@11.2.10: {}
 
   tailwindcss@4.1.11: {}
 


### PR DESCRIPTION
- Installed `swiper` library for the portfolio carousel.
- Created `PortfolioCarousel.tsx` component using Swiper.js:
  - Displays multiple items (4 on desktop, responsive down to 1 on mobile).
  - Features square (1:1) images with category buttons overlaid.
  - Category buttons are styled with white background, black text, and 15px offset from image edges.
  - Utilizes Swiper's default navigation arrows, styled to be black and positioned slightly outside the slide area.
  - Configured for loop (if enough items) and appropriate spacing.
- Integrated `PortfolioCarousel` into a new 'Portfolio' section on the homepage (`app/page.tsx`).
- The section has a yellow background (#fdd154) and a main heading.