### PR TITLE
refactor: Adjust Portfolio carousel layout and slide appearance

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -50,14 +50,13 @@ body {
   font-weight: bold;
 }
 
-/* Posunutí šipek mírně vně obsahu slidů */
-/* Tyto hodnoty bude možná potřeba doladit podle finálního vzhledu a mezer */
+/* Posunutí šipek více ke krajům pro širší layout */
 .portfolio-swiper .swiper-button-prev {
-  left: -10px;
+  left: 10px; /* Posunuto dovnitř od okraje viewportu */
 }
 
 .portfolio-swiper .swiper-button-next {
-  right: -10px;
+  right: 10px; /* Posunuto dovnitř od okraje viewportu */
 }
 
 /* Skrytí šipek na velmi malých obrazovkách, kde je jen jeden slide a loop nemusí být aktivní */

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -114,7 +114,8 @@ export default function Home() {
 
       {/* Sekce Portfolio */}
       <section id="portfolio" className="bg-[#fdd154] py-12 sm:py-16 md:py-20">
-        <div className="container mx-auto px-4">
+        {/* Kontejner pro portfolio, který je širší */}
+        <div className="w-full px-4 sm:px-6 lg:px-8">
           <h2 className="text-3xl sm:text-4xl font-bold text-center text-gray-800 mb-8 sm:mb-12">
             Portfolio
           </h2>

--- a/components/portfolio/PortfolioCarousel.tsx
+++ b/components/portfolio/PortfolioCarousel.tsx
@@ -31,31 +31,28 @@ const PortfolioCarousel: React.FC = () => {
         modules={[Navigation]}
         modules={[Navigation]}
         navigation={true}
-        loop={portfolioItems.length >= 8} // Potřebujeme alespoň 2x max slidesPerView pro plynulý loop
-        slidesPerView={1} // Výchozí pro šířky < 550px
-        spaceBetween={10}  // Menší mezera pro jeden slide
+        loop={portfolioItems.length >= 8}
+        slidesPerView={1}
+        spaceBetween={0} // Odstraněna mezera mezi slidy
         breakpoints={{
-          // od 550px do 799px
           550: {
             slidesPerView: 2,
-            spaceBetween: 15,
+            spaceBetween: 0,
           },
-          // od 800px do 1029px
           800: {
             slidesPerView: 3,
-            spaceBetween: 20,
+            spaceBetween: 0,
           },
-          // od 1030px a více
           1030: {
             slidesPerView: 4,
-            spaceBetween: 20,
+            spaceBetween: 0,
           },
         }}
         className="portfolio-swiper"
       >
         {portfolioItems.map((item) => (
           <SwiperSlide key={item.id}>
-            <div className="relative aspect-square bg-gray-200">
+            <div className="relative aspect-[4/3] bg-gray-200"> {/* Změna poměru stran na 4:3 */}
               <img
                 src={item.src}
                 alt={`Portfolio fotografie - ${item.category}`}


### PR DESCRIPTION
- Modified the 'Portfolio' section to span a wider area, closer to the viewport edges, for larger images.
- Set `spaceBetween` to 0 in the Swiper configuration to remove gaps between slides.
- Changed the aspect ratio of portfolio images from 1:1 (square) to 4:3 (landscape).
- Adjusted the CSS for navigation arrows to better suit the new full-width layout.